### PR TITLE
Updated dependency for nanoutils

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "delightful-bus": "^0.7.3",
-    "nanoutils": "^0.0.15"
+    "nanoutils": "^0.0.x"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
As seen on the [npm documentation](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004) I believe that the dependency for nanoutils should be updated from `^0.0.15` to `^0.0.x` to make it take the latest version as long as it is <0.1.0.

This would grab some benefits since it will not be needed to update the version of nanoutils every time it release a patch release.